### PR TITLE
initial commit of code for taxonomy heatmaps

### DIFF
--- a/procedure/make_taxonomy_heatmaps.ipynb
+++ b/procedure/make_taxonomy_heatmaps.ipynb
@@ -1,0 +1,425 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Make Taxonomy Heatmap"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.core.display import display\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import math\n",
+    "import matplotlib.pyplot as plt\n",
+    "from os.path import abspath,join\n",
+    "taxonomy_folder = abspath(\"../output/taxonomy_summary/\")\n",
+    "output_folder = abspath('../output/')\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First let's define a function to make and output a heatmap graphic. We'll then run several versions for each taxonomic level."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_taxonomy_heatmap(input_path,output_path,raw_data_path, log2_transform = True,\\\n",
+    "  log_scaling_0_replacement_value = -16, cmap = \"mako\", \n",
+    "  row_cluster=False, col_cluster = False,\\\n",
+    "  z_score = None, dpi=300,figsize = (480,120),fontsize=2):\n",
+    "    \"\"\"Generate a taxonomy heatmap\n",
+    "    input_path -- a taxonomy csv file\n",
+    "    output_path -- the graph to output\n",
+    "    raw_data_path -- path to save raw data .tsv to\n",
+    "    log2_transform -- if True, log2 transform data (e.g. 50% => -2, 25% => -3, etc) and \n",
+    "      replace 0 values (which cannot be log transformed) with a low number specified by log_scaling_0_replacement_value\n",
+    "    log_scaling_0_replacement_value -- what to replace 0 values with.\n",
+    "    cmap - colorscheme to use. Examples: \"Blues\",\"Blues_r\",\"veridis\",etc\n",
+    "    taxonomy_csv -- the path to the input taxonomy csv\n",
+    "    output_name -- the name of the output file\n",
+    "    z_score -- can be False (no Z-score normalization), 1 (normalize column by z-score), or 0 (normalize rows)\n",
+    "    standard_score -- can be False (no standard score normalization), 1 (normalize columns), or 0 (normalize rows)\n",
+    "    \"\"\"\n",
+    "    \n",
+    "    #Load the data and set an index\n",
+    "    data = pd.read_csv(input_path)\n",
+    "    labels = pd.DataFrame(data.loc[:,\"index\"])\n",
+    "    data.rename(columns={\"Unassigned;__\":\"d__Unassigned\"},inplace=True)\n",
+    "    #Remove metadata columns by selecting only taxonomy columns\n",
+    "    data = data.loc[:, data.columns.str.startswith(\"d__\")]\n",
+    "    \n",
+    "    #Add back on the feature labels\n",
+    "    data = labels.join(data,how=\"left\")\n",
+    "    data.rename(columns={\"index\":\"SampleID\"},inplace=True)\n",
+    "    data.set_index(\"SampleID\",inplace=True)\n",
+    "    \n",
+    "    #Since these data are unrarified, normalize by proportion in each sample\n",
+    "    data = data.div(data.sum(axis=1), axis=0)\n",
+    "    \n",
+    "    if log2_transform:\n",
+    "        #take the log of the dataframe, substituting 0's (which are undefined in log space)\n",
+    "        #hattip to stackoverflow: \n",
+    "        #https://stackoverflow.com/questions/49207688/pandas-efficiently-avoid-0s-when-taking-log-of-cells-in-dataframe\n",
+    "        def get_log(df):\n",
+    "            return (df.mask(df == 0).applymap(math.log2).fillna(log_scaling_0_replacement_value))\n",
+    "        data = get_log(data)\n",
+    "        \n",
+    "        \n",
+    "\n",
+    "    #Switch rows and colums\n",
+    "    data = data.transpose(copy=True)\n",
+    "    \n",
+    "    #Save exact copy of data used in figure\n",
+    "    #AFTER all relevant transformations have been applied \n",
+    "    #(other than clustering and z_score if selected)\n",
+    "    print(\"Saving raw data to output_path:\")\n",
+    "    data.to_csv(raw_data_path,sep=\"\\t\")\n",
+    "    \n",
+    "      \n",
+    "    #Make the graph\n",
+    "    plt.clf()\n",
+    "    graph = sns.clustermap(data = data,cmap=cmap,metric = \"correlation\",z_score=z_score,xticklabels=1,yticklabels=1,\n",
+    "      row_cluster=row_cluster,col_cluster=col_cluster)\n",
+    "    \n",
+    " \n",
+    "    plt.setp(graph.ax_heatmap.get_yticklabels(), fontsize=fontsize)\n",
+    "    \n",
+    "    #Save result\n",
+    "    print(\"Saving file to output path:\",output_path)\n",
+    "    graph.savefig(output_path,\n",
+    "            dpi=dpi, figsize=figsize)\n",
+    "    plt.clf()\n",
+    "    \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Analyzing taxonomy at level 2\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-2.csv_log2.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-2.csv_log2_row_cluster.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-2.csv.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-2.csv_row_cluster.jpg\n",
+      "Analyzing taxonomy at level 3\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-3.csv_log2.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-3.csv_log2_row_cluster.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-3.csv.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-3.csv_row_cluster.jpg\n",
+      "Analyzing taxonomy at level 4\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-4.csv_log2.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-4.csv_log2_row_cluster.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-4.csv.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-4.csv_row_cluster.jpg\n",
+      "Analyzing taxonomy at level 5\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-5.csv_log2.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-5.csv_log2_row_cluster.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-5.csv.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-5.csv_row_cluster.jpg\n",
+      "Analyzing taxonomy at level 7\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-7.csv_log2.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-7.csv_log2_row_cluster.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-7.csv.jpg\n",
+      "Saving raw data to output_path:\n",
+      "Saving file to output path: /Users/jzaneveld/Dropbox/Zaneveld_Lab_Organization/Projects/Padilla_Gamino_Disease/MWS/output/heatmap_of_level-7.csv_row_cluster.jpg\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 432x288 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<Figure size 720x720 with 0 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "\n",
+    "    \n",
+    "levels_to_analyze = [2,3,4,5,7] \n",
+    "for level in levels_to_analyze:\n",
+    "    print(f\"Analyzing taxonomy at level {level}\")\n",
+    "    current_file = f\"level-{level}.csv\"\n",
+    "    input_path = join(taxonomy_folder,current_file)\n",
+    "    \n",
+    "    #Use smaller font for more specific levels\n",
+    "    fontsize = round(14.0/level)\n",
+    "    \n",
+    "    #Output log transformed results\n",
+    "    \n",
+    "    #Set the cmap to a dark colorscheme which looks better with \n",
+    "    #log data\n",
+    "    cmap = \"mako\"\n",
+    "    \n",
+    "    output_path = join(output_folder,f'heatmap_of_{current_file}_log2.jpg')\n",
+    "    raw_data_path = join(output_folder,f'raw_data_of_{current_file}_log2.tsv')\n",
+    "    make_taxonomy_heatmap(input_path,output_path,raw_data_path,log2_transform=True,fontsize=fontsize,cmap=cmap)\n",
+    "    \n",
+    "    output_path = join(output_folder,f'heatmap_of_{current_file}_log2_row_cluster.jpg')\n",
+    "    raw_data_path = join(output_folder,f'raw_data_of_{current_file}_log2_row_cluster.tsv')\n",
+    "    make_taxonomy_heatmap(input_path,output_path,raw_data_path,log2_transform=True,row_cluster=True,fontsize=fontsize,cmap=cmap)\n",
+    "   \n",
+    "    #Output raw clustermaps\n",
+    "    #Use a light colorscheme which makes it easier to see very small numbers as faint 'bands'\n",
+    "    cmap = \"Blues\"\n",
+    "    output_path = join(output_folder,f'heatmap_of_{current_file}.jpg')\n",
+    "    raw_data_path = join(output_folder,f'raw_data_of_{current_file}.tsv')\n",
+    "    make_taxonomy_heatmap(input_path,output_path,raw_data_path,log2_transform=False,fontsize=fontsize,cmap=cmap)\n",
+    "    \n",
+    "    output_path = join(output_folder,f'heatmap_of_{current_file}_row_cluster.jpg')\n",
+    "    raw_data_path = join(output_folder,f'raw_data_of_{current_file}_row_cluster.tsv')\n",
+    "    make_taxonomy_heatmap(input_path,output_path,raw_data_path,log2_transform=False,row_cluster=True,fontsize=fontsize,cmap=cmap)\n",
+    "    \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This commit adds a Jupyter notebook for generating taxonomy heatmaps. The script assumes the .csv files will be saved in output/taxonomy_summary/, that taxonomy levels are named in the convention d__Bacteria;p__Proteobacteria etc etc,  and named by level (e.g. level-1.csv etc)